### PR TITLE
Change in Line 308

### DIFF
--- a/R/transition.R
+++ b/R/transition.R
@@ -305,7 +305,7 @@ setMethod("transition", signature(x = "RasterBrick"),
 			dataCells <- xy[,1]
 			adj <- adjacent(x, cells=dataCells, pairs=TRUE,
 			                target=dataCells, directions=directions)
-			x.minus.y <- xy[adj[,1],-1]-xy[adj[,2],-1]
+			x.minus.y <- getValues(x)[adj[,1],] - getValues(x)[adj[,2],]
 			cov.inv <- solve(cov(xy[,-1]))
 			mahaldistance <- apply(x.minus.y,1,function(x){sqrt((x%*%cov.inv)%*%x)})
 			mahaldistance <- mean(mahaldistance)/(mahaldistance+mean(mahaldistance))


### PR DESCRIPTION
Dear package authors,

Raster bricks with NA values produce errors.

Reproducable example:
x <- raster(matrix(data = c(NA, 20, 7, NA, NA, 18, NA, 5, 1, 21, 3, 15, 22, 17, 12, 14), nrow = 4, ncol = 4, byrow = T))
y <- raster(matrix(data = c(690, NA, 673, 442, 750, 620, 680, 491, 467, NA, 624, 590, NA, NA, 727, 462), nrow = 4, ncol = 4, byrow = T))
x <- brick(x, y)
xy <- cbind(1:ncell(x),getValues(x))
xy <- na.omit(xy)
dataCells <- xy[,1]
adj <- adjacent(x, cells=dataCells, pairs=TRUE, target=dataCells, directions=directions)
x.minus.y <- xy[adj[,1],-1]-xy[adj[,2],-1]
Error in xy[adj[, 1], -1] : subscript out of bounds

I therefore suggest to replace "x.minus.y <- xy[adj[,1],-1]-xy[adj[,2],-1]" in line 308 with "x.minus.y <- getValues(x)[adj[,1],] - getValues(x)[adj[,2],]".

Kind regards,
Christian Düben